### PR TITLE
Bug fix and functionality improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,11 @@
 
 ```powershell
 function New-WindowsSandbox {
-    # set the terminal location to your repo directory
-	Set-Location 'C:\Github\Windows-Sandbox'
-
     # include the powershell script
 	. 'C:\Github\Windows-Sandbox\Start-WindowsSandbox.ps1'
 
     # run the function with your params
-	Start-WindowsSandbox -RepoDir "C:\Github\" -PsProfileDir "C:\Documents\PowerShell\" -WindowsTerminal -VsCode -Firefox -SevenZip -Git -ChocoPackages @([pscustomobject]@{ command = 'nodejs.install'; params = ''; })
+	Start-WindowsSandbox -PsProfileDir "C:\Documents\PowerShell\" -WindowsTerminal -VsCode -Firefox -SevenZip -Git -ChocoPackages @([pscustomobject]@{ command = 'nodejs.install'; params = ''; })
 }
 ```
 

--- a/WSBshare/SandboxSettings.ps1
+++ b/WSBshare/SandboxSettings.ps1
@@ -1,16 +1,18 @@
 Class SandboxSettings {
     [bool]$InstallChocolatey = $False
-
     [object[]]$ChocoPackages
+    [string]$LaunchScript
 
-    SandboxSettings([object[]]$chocoPackages) {
+    SandboxSettings([object[]]$chocoPackages, [string]$launchScript) {
         $this.ChocoPackages = $chocoPackages
+        $this.LaunchScript = $launchScript
 
         $this.InstallChocolatey = $this.ChocoPackages.count -gt 0;
     }
 
     SandboxSettings([PSCustomObject]$settings) {
         $this.ChocoPackages = $settings.ChocoPackages
+        $this.LaunchScript = $settings.LaunchScript
 
         $this.InstallChocolatey = $this.ChocoPackages.count -gt 0;
     }

--- a/WSBshare/Set-SandboxDesktop.ps1
+++ b/WSBshare/Set-SandboxDesktop.ps1
@@ -1,7 +1,5 @@
 # Set-SandboxDesktop.ps1
 
-param([string]$repoPath)
-
 function Update-Wallpaper {
   [cmdletbinding(SupportsShouldProcess)]
     Param(
@@ -38,7 +36,7 @@ function Update-Wallpaper {
 }
 
 #configure wallpaper
-Set-ItemProperty 'hkcu:\Control Panel\Desktop\' -Name Wallpaper -Value $(Join-Path $repoPath "Windows-Sandbox\WSBshare\SuperPowerShell.jpg")
+Set-ItemProperty 'hkcu:\Control Panel\Desktop\' -Name Wallpaper -Value $(Join-Path $PSScriptRoot "SuperPowerShell.jpg")
 Set-ItemProperty 'hkcu:\Control Panel\Desktop\' -Name WallpaperOriginX -value 0
 Set-ItemProperty 'hkcu:\Control Panel\Desktop\' -Name WallpaperOriginY -value 0
 Set-ItemProperty 'hkcu:\Control Panel\Desktop\' -Name WallpaperStyle -value 10


### PR DESCRIPTION
- Remove requirement for repo dir parameter and use PSScriptRoot instead.
- Fix to allow script to be launched from anywhere.
- Allow pointing at a ps1 file that will be copied to the sandbox and run after all other initialisation, utilise sandbox settings json.
- Remove configuration and sandbox settings from the parameter list as these can be constants.
- Add parameter to spec all predefined chocolatey packages should be installed.